### PR TITLE
Added support for paged searches

### DIFF
--- a/lib/WWW/Google/Places.pm
+++ b/lib/WWW/Google/Places.pm
@@ -326,11 +326,10 @@ sub paged_search {
     my $params = { location => 1, radius => 1, types => 0, name => 0, pagetoken => 0 };
     my ($pagetoken, $contents, @search_results);
     do {
-       $values->{pagetoken} = $pagetoken
-          if defined $pagetoken;
-       
-       sleep(2); # pagetokens take a few seconds to become active
-
+       if ( defined $pagetoken) {
+          $values->{pagetoken} = $pagetoken;
+          sleep(2); # pagetokens take a few seconds to become active
+       }
        my $url      = $self->_url('search', $params, $values);
        my $response = $self->get($url);
        $contents    = from_json( $response->{content} );

--- a/lib/WWW/Google/Places.pm
+++ b/lib/WWW/Google/Places.pm
@@ -294,16 +294,52 @@ returns a list of objects of type L<WWW::Google::Places::SearchResult>.
 
 =cut
 
+
 sub search {
     my ($self, $values) = @_;
-
+   
     my $params   = { location => 1, radius => 1, types => 0, name => 0 };
     my $url      = $self->_url('search', $params, $values);
     my $response = $self->get($url);
     my $contents = from_json($response->{content});
-
+   
     my @results  = map { WWW::Google::Places::SearchResult->new($_) } @{$contents->{results}};
     return @results;
+}
+
+=head2 paged_search(\%params)
+
+Accepts the same values as C<search(\%params)> but handles queries that 
+have multiple pages worth of data. Using paged_search the max number of results is 60
+(or 3 pages worth) 
+L<https://developers.google.com/places/documentation/search#PlaceSearchRequests>
+
+Note: due to the way that Google handles the paging of results there is a 
+required sleep of 2 seconds between each requests so that the Google pageTokens
+can become active.
+
+=cut
+
+sub paged_search {
+    my ($self, $values) = @_;
+
+    my $params = { location => 1, radius => 1, types => 0, name => 0, pagetoken => 0 };
+    my ($pagetoken, $contents, @search_results);
+    do {
+       $values->{pagetoken} = $pagetoken
+          if defined $pagetoken;
+       
+       sleep(2); # pagetokens take a few seconds to become active
+
+       my $url      = $self->_url('search', $params, $values);
+       my $response = $self->get($url);
+       $contents    = from_json( $response->{content} );
+
+       push @search_results,
+          map { WWW::Google::Places::SearchResult->new($_) } @{$contents->{results}};
+    } while $pagetoken = $contents->{next_page_token};
+    
+    return @search_results;
 }
 
 =head2 details($place_id)
@@ -488,7 +524,6 @@ sub place_checkins {
 
 sub _url {
     my ($self, $type, $params, $values) = @_;
-
     my $url = sprintf("%s/%s/%s?key=%s&sensor=%s&language=%s",
                       $BASE_URL, $type, $self->output, $self->api_key,
                       $self->sensor, $self->language);

--- a/lib/WWW/Google/Places/Params.pm
+++ b/lib/WWW/Google/Places/Params.pm
@@ -71,7 +71,8 @@ my $MORE_PLACE_TYPES = {
     'premise'                     => 1, 'room'                        => 1, 'route'                       => 1, 'street_address'      => 1,
     'street_number'               => 1, 'sublocality'                 => 1, 'sublocality_level_4'         => 1, 'sublocality_level_5' => 1,
     'sublocality_level_3'         => 1, 'sublocality_level_2'         => 1, 'sublocality_level_1'         => 1, 'subpremise'          => 1,
-    'transit_station'             => 1 };
+    'transit_station'             => 1 
+};
 
 our $STATUS = {
     'OK'               => 'No errors occurred; the place was successfully detected and at least one result was returned.',
@@ -144,6 +145,7 @@ our $FIELDS = {
     'language'     => { check => sub { check_language(@_) }, type => 's' },
     'address'      => { check => sub { check_str(@_)      }, type => 's' },
     'reference'    => { check => sub { check_str(@_)      }, type => 's' },
+    'pagetoken'    => { check => sub { check_str(@_)      }, type => 's' },
 };
 
 sub validate {
@@ -163,7 +165,7 @@ sub validate {
         die "ERROR: Received undefined mandatory param: $field"
             if ($fields->{$field} && !defined $values->{$field});
 
-	$FIELDS->{$field}->{check}->($values->{$field})
+        $FIELDS->{$field}->{check}->($values->{$field})
             if defined $values->{$field};
     }
 }

--- a/t/05-paging.t
+++ b/t/05-paging.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+use 5.006;
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use WWW::Google::Places;
+
+my $places_service = 
+    WWW::Google::Places->new( api_key => $ENV{GOOGLE_API_KEY} );
+my $los_angeles = '34.0522222,-118.2427778';
+{
+    my @results = $places_service->search( 
+       { location => $los_angeles, 
+         radius   => 500,
+         types    => 'bar|restaurant',
+       },
+    );
+
+    cmp_ok( 
+       scalar @results, '<=', 20,
+       'un-paged search returns a max of 20 results'
+    );
+}
+
+{   # test paged_search
+    # can only test the upper bound of results because some lat/longs
+    # can still return <= 20 results 
+    my @results = $places_service->paged_search( 
+       { location => $los_angeles, 
+         radius   => 500,
+         types    => 'bar|restaurant',
+       },
+    );
+
+    cmp_ok(
+       scalar @results, '<=', 60,
+       'paged search returns a max of 60 results'
+    );
+}


### PR DESCRIPTION
The Google Places API allows for up to 60 results split into 3 pages. Each API response contains an element contents->{next_page_token}. If this value is defined then there are more than 20 results. A new method paged_search(\%params) was added to WWW::Google::Places to support gathering all possible results. A new test t/05-paging.t was added to this this method.
